### PR TITLE
Improve CI workflow error messaging for unknown platforms

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
               exit 1
             }
           } else {
-            Write-Error "Unknown platform ${{matrix.platform}} to get ml<XXX>.exe in PATH."
+            Write-Error "Unknown platform ${{matrix.platform}} - no assembler configured for testing in PATH."
             exit 1
           }
 


### PR DESCRIPTION
Update the error message in the CI workflow to be more descriptive when an unknown platform is encountered during assembler testing.

🤖 Generated with [Claude Code](https://claude.ai/code)