### PR TITLE
bump: Bump NodeJs to 24 as 20 is deprecated

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,5 +23,5 @@ outputs:
     description: "The resulting location of ml (x86), ml64 (x64) or armasm64 (arm64) for your inputs"
 
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"


### PR DESCRIPTION
See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/