### PR TITLE
ci: switch to windows-2025-vs2026 ahead of VS 2026 migration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,12 @@ jobs:
       matrix:
         include:
           - platform: x86
+            os: windows-2022
+            toolchain: stable
+          - platform: x64
+            os: windows-2022
+            toolchain: stable
+          - platform: x86
             os: windows-2025-vs2026
             toolchain: stable
           - platform: x64

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,10 +34,10 @@ jobs:
       matrix:
         include:
           - platform: x86
-            os: windows-latest
+            os: windows-2025-vs2026
             toolchain: stable
           - platform: x64
-            os: windows-latest
+            os: windows-2025-vs2026
             toolchain: stable
           - platform: arm64
             os: windows-11-arm

--- a/README.md
+++ b/README.md
@@ -14,11 +14,21 @@ Add the following step to your workflow:
 - uses: glslang/setup-masm@v1.4
 ```
 
+## Runner compatibility
+
+This action supports Visual Studio 2022 and Visual Studio 2026. It uses `vswhere` to locate whichever VS version is installed on the runner, so it works without any configuration changes as GitHub migrates `windows-latest` to VS 2026 (rollout June 8–15, 2026).
+
+| Runner label | Visual Studio |
+|---|---|
+| `windows-2022` | VS 2022 |
+| `windows-2025-vs2026` / `windows-latest` (after June 15, 2026) | VS 2026 |
+| `windows-11-arm` | VS 2022+ |
+
 ## Inputs
 
-- `vs-version`: The version of Visual Studio to use. Defaults to `'latest'`.
+- `vs-version`: The version of Visual Studio to use. Defaults to `'latest'` (newest installed).
 - `vs-prerelease`: Whether to include prerelease versions of Visual Studio. Defaults to `'false'`.
-- `vs-architecture`: By default the action will use the x64 architecture for MASM, but it is possible to target the x86 or arm64 versions instead. Valid input values are `'x64'`, `'x86'` and `'arm64'`. Note that the success of these will rely on the runner OS. Defaults to `'x64'`. 
+- `vs-architecture`: By default the action will use the x64 architecture for MASM, but it is possible to target the x86 or arm64 versions instead. Valid input values are `'x64'`, `'x86'` and `'arm64'`. Note that the success of these will rely on the runner OS. Defaults to `'x64'`.
 
 ## Outputs
 
@@ -45,8 +55,6 @@ jobs:
       - uses: microsoft/setup-msbuild@v3
       - uses: glslang/setup-masm@v1.4
         with:
-          vs-version: '2022'
-          vs-prerelease: 'true'
           vs-architecture: 'x86'
 ```
 


### PR DESCRIPTION
## Summary

- GitHub is migrating `windows-latest` and `windows-2025` to use Visual Studio 2026 by default between **June 8–15, 2026**
- Switches the x86/x64 CI matrix entries from `windows-latest` → `windows-2025-vs2026` to proactively validate the action against VS 2026 before the forced rollout
- The action itself (`src/main.ts`) uses `vswhere -latest` and is not tied to any specific VS version, so no logic changes are required — only the runner label needs updating

## Test plan

- [ ] CI passes on `windows-2025-vs2026` for both x86 and x64 matrix entries
- [ ] CI passes on `windows-11-arm` for arm64 (unchanged)
- [ ] `ml.exe` (x86), `ml64.exe` (x64), and `armasm64.exe` (arm64) are each found in PATH after the action runs

https://claude.ai/code/session_011WjuYJ2CQtQK1aE9gzeox8

---
_Generated by [Claude Code](https://claude.ai/code/session_011WjuYJ2CQtQK1aE9gzeox8)_