### PR TITLE
chore: add CodeRabbit config and README badge

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: en-US
+early_access: false
+reviews:
+  profile: assertive
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+  path_filters:
+    - "!dist/**"
+    - "!package-lock.json"
+  path_instructions:
+    - path: "src/**/*.ts"
+      instructions: >-
+        This is the source for a GitHub Action that adds MASM to the PATH on
+        Windows runners. The action is bundled to dist/index.js with esbuild;
+        flag any change to src that would require re-running `npm run all` if
+        dist/ was not regenerated. Watch for correctness of the constructed
+        tool path and for unhandled errors from vswhere or file reads.
+chat:
+  auto_reply: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# setup-masm [![Build Status](https://github.com/glslang/setup-masm/actions/workflows/ci.yaml/badge.svg)](https://github.com/glslang/setup-masm/actions) [![GitHub release](https://img.shields.io/github/v/release/glslang/setup-masm?logo=github)](https://github.com/marketplace/actions/setup-masm)
+# setup-masm [![Build Status](https://github.com/glslang/setup-masm/actions/workflows/ci.yaml/badge.svg)](https://github.com/glslang/setup-masm/actions) [![GitHub release](https://img.shields.io/github/v/release/glslang/setup-masm?logo=github)](https://github.com/marketplace/actions/setup-masm) [![CodeRabbit Reviews](https://img.shields.io/coderabbit/prs/github/glslang/setup-masm?utm_source=oss&utm_medium=github&utm_campaign=glslang%2Fsetup-masm&labelColor=171717&color=FF570A&label=CodeRabbit+Reviews)](https://coderabbit.ai)
 
 A GitHub Action to facilitate configuring MASM (Microsoft Macro Assembler) in the workflow PATH to use x64, x86 and ARM64 assembly in Win32 applications.
 


### PR DESCRIPTION
## What

- Add `.coderabbit.yml` configuring CodeRabbit reviews:
  - `assertive` review profile
  - `dist/**` and `package-lock.json` excluded from review (generated/bundled output)
  - `src/**/*.ts` path instruction noting the esbuild bundle to `dist/index.js` and what to watch for (tool-path construction, vswhere/file-read error handling)
  - auto-review enabled, skips drafts
- Add the **CodeRabbit Reviews** badge to the README title line, alongside Build Status and GitHub release.

## Notes

The badge shows the live PR review count once CodeRabbit is installed on the repo; until the first review runs the shields.io endpoint shows "no data".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository documentation with additional integration badge.
  * Added configuration for code review automation settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/glslang/setup-masm/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->